### PR TITLE
av1d: add support for MFX_EXTBUFF_VIDEO_SIGNAL_INFO

### DIFF
--- a/_studio/mfx_lib/decode/av1/src/mfx_av1_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/av1/src/mfx_av1_dec_decode.cpp
@@ -1242,6 +1242,18 @@ mfxStatus VideoDECODEAV1::FillVideoParam(UMC_AV1_DECODER::AV1DecoderParams const
         || par->mfx.FrameInfo.FourCC == MFX_FOURCC_Y416)
         par->mfx.FrameInfo.Shift = 1;
 
+    // video signal section
+    mfxExtVideoSignalInfo * videoSignal = (mfxExtVideoSignalInfo *)GetExtendedBuffer(par->ExtParam, par->NumExtParam, MFX_EXTBUFF_VIDEO_SIGNAL_INFO);
+    if (videoSignal)
+    {
+        videoSignal->VideoFormat = static_cast<mfxU16>(vp->info.color_format);
+        videoSignal->VideoFullRange = static_cast<mfxU16>(vp->color_range);
+        videoSignal->ColourDescriptionPresent = static_cast<mfxU16>(vp->color_description_present_flag);
+        videoSignal->ColourPrimaries = static_cast<mfxU16>(vp->color_primaries);
+        videoSignal->TransferCharacteristics = static_cast<mfxU16>(vp->transfer_characteristics);
+        videoSignal->MatrixCoefficients = static_cast<mfxU16>(vp->matrix_coefficients);
+    }
+
     return MFX_ERR_NONE;
 }
 

--- a/_studio/shared/umc/codec/av1_dec/include/umc_av1_dec_defs.h
+++ b/_studio/shared/umc/codec/av1_dec/include/umc_av1_dec_defs.h
@@ -346,6 +346,7 @@ namespace UMC_AV1_DECODER
         uint32_t subsampling_x;
         uint32_t subsampling_y;
         uint32_t separate_uv_delta_q;
+        uint32_t color_description_present_flag;
     };
 
     struct SequenceHeader

--- a/_studio/shared/umc/codec/av1_dec/include/umc_av1_decoder.h
+++ b/_studio/shared/umc/codec/av1_dec/include/umc_av1_decoder.h
@@ -59,6 +59,11 @@ namespace UMC_AV1_DECODER
             , anchors_loaded(false)
             , skip_first_frames(0)
             , pre_loaded_anchors(nullptr)
+            , color_range(0)
+            , color_description_present_flag(0)
+            , color_primaries(AOM_CICP_CP_UNSPECIFIED)
+            , transfer_characteristics(AOM_CICP_TC_UNSPECIFIED)
+            , matrix_coefficients(AOM_CICP_MC_UNSPECIFIED)
         {}
 
     public:
@@ -72,6 +77,11 @@ namespace UMC_AV1_DECODER
         bool                 anchors_loaded;
         uint32_t             skip_first_frames;
         mfxFrameSurface1**   pre_loaded_anchors;
+        uint32_t             color_range;
+        uint32_t             color_description_present_flag;
+        uint32_t             color_primaries;
+        uint32_t             transfer_characteristics;
+        uint32_t             matrix_coefficients;
     };
 
     class ReportItem // adopted from HEVC/AVC decoders

--- a/_studio/shared/umc/codec/av1_dec/src/umc_av1_bitstream.cpp
+++ b/_studio/shared/umc/codec/av1_dec/src/umc_av1_bitstream.cpp
@@ -91,8 +91,8 @@ namespace UMC_AV1_DECODER
 
         config.mono_chrome = profile != 1 ? bs.GetBit() : 0;
 
-        uint32_t color_description_present_flag = bs.GetBit();
-        if (color_description_present_flag)
+        config.color_description_present_flag = bs.GetBit();
+        if (config.color_description_present_flag)
         {
             config.color_primaries = bs.GetBits(8);
             config.transfer_characteristics = bs.GetBits(8);

--- a/_studio/shared/umc/codec/av1_dec/src/umc_av1_decoder.cpp
+++ b/_studio/shared/umc/codec/av1_dec/src/umc_av1_decoder.cpp
@@ -1145,6 +1145,13 @@ namespace UMC_AV1_DECODER
 
         par.film_grain = sh.film_grain_param_present;
 
+        // video signal
+        par.color_range = sh.color_config.color_range;
+        par.color_description_present_flag = sh.color_config.color_description_present_flag;
+        par.color_primaries = sh.color_config.color_primaries;
+        par.transfer_characteristics = sh.color_config.transfer_characteristics;
+        par.matrix_coefficients = sh.color_config.matrix_coefficients;
+
         return UMC::UMC_OK;
     }
 


### PR DESCRIPTION
User may get video signal info via MFX_EXTBUFF_VIDEO_SIGNAL_INFO buffer when calling MFXVideoDECODE_DecodeHeader() for H.264, H.265 etc, let's add the support for AV1 too.