### PR TITLE
[jpegd] Add quick seek function to bitstream

### DIFF
--- a/_studio/shared/umc/codec/jpeg_common/include/bitstreamin.h
+++ b/_studio/shared/umc/codec/jpeg_common/include/bitstreamin.h
@@ -57,6 +57,7 @@ public:
   JERRCODE ReadByte(int* byte);
   JERRCODE ReadWord(int* word);
   JERRCODE ReadDword(int* dword);
+  JERRCODE SeekAfterByte(int byte, int* skipped = NULL);
 
 protected:
   CBaseStreamInput* m_in;

--- a/_studio/shared/umc/codec/jpeg_common/include/bitstreamin.h
+++ b/_studio/shared/umc/codec/jpeg_common/include/bitstreamin.h
@@ -57,7 +57,7 @@ public:
   JERRCODE ReadByte(int* byte);
   JERRCODE ReadWord(int* word);
   JERRCODE ReadDword(int* dword);
-  JERRCODE SeekAfterByte(int byte, int* skipped = NULL);
+  JERRCODE SeekAfterByte(uint8_t byte, int* skipped = NULL);
 
 protected:
   CBaseStreamInput* m_in;

--- a/_studio/shared/umc/codec/jpeg_common/src/bitstreamin.cpp
+++ b/_studio/shared/umc/codec/jpeg_common/src/bitstreamin.cpp
@@ -286,7 +286,7 @@ JERRCODE CBitStreamInput::SeekAfterByte(uint8_t byte, int* skipped)
     m_nUsedBytes += cnt;
   }
 
-  cnt = p;
+  cnt = (int) p;
   res += cnt;
   ++cnt;
   m_currPos += cnt;

--- a/_studio/shared/umc/codec/jpeg_common/src/bitstreamin.cpp
+++ b/_studio/shared/umc/codec/jpeg_common/src/bitstreamin.cpp
@@ -257,14 +257,14 @@ JERRCODE CBitStreamInput::ReadDword(int* dword)
 } // CBitStreamInput::ReadDword()
 
 
-JERRCODE CBitStreamInput::SeekAfterByte(int byte, int* skipped)
+JERRCODE CBitStreamInput::SeekAfterByte(uint8_t byte, int* skipped)
 {
   JERRCODE jerr;
   int cnt, res = 0;
   unsigned char bytes[] = { byte };
   unsigned char* buf;
   std::size_t p;
-  std::string pattern(bytes, bytes + 1); 
+  std::string pattern(bytes, bytes + 1);
 
   for (;;)
   {
@@ -283,14 +283,14 @@ JERRCODE CBitStreamInput::SeekAfterByte(int byte, int* skipped)
     if(p != std::string::npos) break;
     res += cnt;
     m_currPos += cnt;
-    m_nUsedBytes += cnt; 
+    m_nUsedBytes += cnt;
   }
 
   cnt = p;
   res += cnt;
   ++cnt;
   m_currPos += cnt;
-  m_nUsedBytes += cnt; 
+  m_nUsedBytes += cnt;
   if(skipped)
     *skipped = res;
 

--- a/_studio/shared/umc/codec/jpeg_dec/src/jpegdec_base.cpp
+++ b/_studio/shared/umc/codec/jpeg_dec/src/jpegdec_base.cpp
@@ -314,22 +314,9 @@ JERRCODE CJPEGDecoderBase::NextMarker(JMARKER* marker)
 
   for(;;)
   {
-    jerr = m_BitStreamIn.ReadByte(&c);
+    jerr = m_BitStreamIn.SeekAfterByte(0xff, &n);
     if(JPEG_OK != jerr)
       return jerr;
-
-    if(c != 0xff)
-    {
-      do
-      {
-        n++;
-
-        jerr = m_BitStreamIn.ReadByte(&c);
-        if(JPEG_OK != jerr)
-          return jerr;
-
-      } while(c != 0xff);
-    }
 
     do
     {


### PR DESCRIPTION
Use C++ std::string::find function to look for specific byte quickly.

When there is a lot of junk data in the jpeg stream, it took quite some time to look for the 0xff and the marker.
Try using C++ std::string find function to look for that; it greatly improve the speed.