### PR TITLE
[encode] Allow GPB set to off for HEVC encode

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_iddi_packer.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_iddi_packer.h
@@ -61,7 +61,7 @@ protected:
     void HardcodeCapsCommon(EncodeCapsHevc& caps, const mfxVideoParam& par)
     {
         caps.SliceIPOnly        = IsOn(par.mfx.LowPower);
-        caps.msdk.PSliceSupport = false;
+        caps.msdk.PSliceSupport = true;
     }
 };
 


### PR DESCRIPTION
HEVC encode caps did not enable "GPB off" before, change HEVC encode caps to enable it. Otherwise some android cts test cannot pass.