### PR TITLE
[Av1e/lib]correct chrome format by the user parameter from upper layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ endif()
 
 
 # Througout this project MFX_VERSION refers to uAPI version and MEDIA_VERSION refers to product version
-set(MEDIA_VERSION 23.4.4) # auto-update
+set(MEDIA_VERSION 23.4.5) # auto-update
 set(MEDIA_VERSION_STR "${MEDIA_VERSION}${MEDIA_VERSION_EXTRA}" CACHE STRING "" FORCE)
 
 if(CMAKE_SYSTEM_NAME MATCHES WindowsStore)

--- a/_studio/mfx_lib/encode_hw/av1/linux/base/av1ehw_base_va_lin.cpp
+++ b/_studio/mfx_lib/encode_hw/av1/linux/base/av1ehw_base_va_lin.cpp
@@ -121,7 +121,7 @@ void DDI_VA::Query1NoCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
         SetIf(targetChromaFormat, profile == MFX_PROFILE_AV1_HIGH, MFX_CHROMAFORMAT_YUV444);
         if (pCO3)
         {
-            SetIf(targetChromaFormat, !pCO3->TargetChromaFormatPlus1, pCO3->TargetChromaFormatPlus1 - 1);
+            SetIf(targetChromaFormat, pCO3->TargetChromaFormatPlus1, pCO3->TargetChromaFormatPlus1 - 1);
         }
 
         MFX_SAFE_CALL(SetDDIID(bitDepth, targetChromaFormat));


### PR DESCRIPTION
if there are extCodingOption3 from user, vpl should respect user setting

Signed-off-by: Carl Zhang <carl.zhang@intel.com>