### PR TITLE
Remove double copy to/from GPU in hwupload and hwdownload

### DIFF
--- a/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
+++ b/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
@@ -7158,6 +7158,16 @@ mfxStatus ConfigureExecuteParams(
         }
     }
 
+    if ( (0 == memcmp(&videoParam.vpp.In, &videoParam.vpp.Out, sizeof(mfxFrameInfo))) &&
+         executeParams.IsDoNothing() )
+    {
+        config.m_bCopyPassThroughEnable = true;
+    }
+    else
+    {
+        config.m_bCopyPassThroughEnable = false; // after Reset() parameters may be changed,
+                                                 // flag should be disabled
+    }
 
     if (inDNRatio == outDNRatio && !executeParams.bVarianceEnable && !executeParams.bComposite &&
             !(config.m_extConfig.mode == IS_REFERENCES) )


### PR DESCRIPTION
This commit is planned to remove double copying to/from GPU in hwupload and hwdownload.

It was tested on VPL GPU Runtime 2024Q4 Release - 24.4.4 and also on top of main branch.
And it was successful there.
It gave performance gain of 16-21% for below command line:
ffmpeg \
      -qsv_device /dev/dri/renderD128 -hwaccel qsv \
      -pix_fmt yuv422p10le -video_size 1920x1080 -i /videos/1920x1080p10le_1.yuv \
      -pix_fmt yuv422p10le -video_size 1920x1080 -i /videos/1920x1080p10le_1.yuv \
      -pix_fmt yuv422p10le -video_size 1920x1080 -i /videos/1920x1080p10le_1.yuv \
      -pix_fmt yuv422p10le -video_size 1920x1080 -i /videos/1920x1080p10le_1.yuv \
      -pix_fmt yuv422p10le -video_size 1920x1080 -i /videos/1920x1080p10le_1.yuv \
      -pix_fmt yuv422p10le -video_size 1920x1080 -i /videos/1920x1080p10le_1.yuv \
      -pix_fmt yuv422p10le -video_size 1920x1080 -i /videos/1920x1080p10le_1.yuv \
      -pix_fmt yuv422p10le -video_size 1920x1080 -i /videos/1920x1080p10le_1.yuv \
      -filter_complex "[0:v]hwupload,scale_qsv=iw/4:ih/2[out0]; \
                       [1:v]hwupload,scale_qsv=iw/4:ih/2[out1]; \
                       [2:v]hwupload,scale_qsv=iw/4:ih/2[out2]; \
                       [3:v]hwupload,scale_qsv=iw/4:ih/2[out3]; \
                       [4:v]hwupload,scale_qsv=iw/4:ih/2[out4]; \
                       [5:v]hwupload,scale_qsv=iw/4:ih/2[out5]; \
                       [6:v]hwupload,scale_qsv=iw/4:ih/2[out6]; \
                       [7:v]hwupload,scale_qsv=iw/4:ih/2[out7]; \
                       [out0][out1][out2][out3] \
                       [out4][out5][out6][out7] \
                       xstack_qsv=inputs=8:\
                       layout=0_0|w0_0|0_h0|w0_h0|w0+w1_0|w0+w1+w2_0|w0+w1_h0|w0+w1+w2_h0, \
                       format=y210le,format=yuv422p10le" \
      /videos/recv_1920x1080p10le.yuv


However we also noticed a bug that is disappearing after applying our changes.

The bug is: the result video file has repeated (4) lines (rows) in the lowest part of the picture.
And probably lost some of the lines (rows) somewhere above.

You can see it with the exemplary command of ffmpeg with qsv plug-in:

ffmpeg \
      -qsv_device /dev/dri/renderD128 -hwaccel qsv \
      -pix_fmt yuv422p10le -video_size 1920x1080 -i /videos/1920x1080p10le_1.yuv \
      -filter_complex "[0:v]hwupload,scale_qsv=iw/4:ih/2,format=y210le,format=yuv422p10le" \
      /videos/recv_1920x1080p10le.yuv
	  
Signed-off-by: Szymon Kolelis <szymon.kolelis@intel.com>

