### PR TITLE
[VP] Fix missing entries in PicStruct validation

### DIFF
--- a/_studio/mfx_lib/vpp/src/mfx_vpp_sw_core.cpp
+++ b/_studio/mfx_lib/vpp/src/mfx_vpp_sw_core.cpp
@@ -1026,11 +1026,21 @@ mfxStatus VideoVPPBase::Query(VideoCORE * core, mfxVideoParam *in, mfxVideoParam
 
         // Check for invalid cases
         if (out->vpp.In.PicStruct != MFX_PICSTRUCT_PROGRESSIVE &&
-            out->vpp.In.PicStruct != MFX_PICSTRUCT_FIELD_TFF   &&
-            out->vpp.In.PicStruct != MFX_PICSTRUCT_FIELD_BFF   &&
+            out->vpp.In.PicStruct != (MFX_PICSTRUCT_PROGRESSIVE | MFX_PICSTRUCT_FRAME_DOUBLING) &&
+            out->vpp.In.PicStruct != (MFX_PICSTRUCT_PROGRESSIVE | MFX_PICSTRUCT_FRAME_TRIPLING) &&
+            out->vpp.In.PicStruct != (MFX_PICSTRUCT_PROGRESSIVE | MFX_PICSTRUCT_FIELD_BFF) &&
+            out->vpp.In.PicStruct != (MFX_PICSTRUCT_PROGRESSIVE | MFX_PICSTRUCT_FIELD_TFF) &&
+            out->vpp.In.PicStruct != (MFX_PICSTRUCT_PROGRESSIVE | MFX_PICSTRUCT_FIELD_BFF | MFX_PICSTRUCT_FIELD_REPEATED) &&
+            out->vpp.In.PicStruct != (MFX_PICSTRUCT_PROGRESSIVE | MFX_PICSTRUCT_FIELD_TFF | MFX_PICSTRUCT_FIELD_REPEATED) &&
+            out->vpp.In.PicStruct != MFX_PICSTRUCT_FIELD_BFF &&
+            out->vpp.In.PicStruct != MFX_PICSTRUCT_FIELD_TFF &&
             out->vpp.In.PicStruct != MFX_PICSTRUCT_FIELD_SINGLE &&
             out->vpp.In.PicStruct != MFX_PICSTRUCT_FIELD_TOP && // Field pass-through
+            out->vpp.In.PicStruct != (MFX_PICSTRUCT_FIELD_TOP | MFX_PICSTRUCT_FIELD_PAIRED_NEXT) &&
+            out->vpp.In.PicStruct != (MFX_PICSTRUCT_FIELD_TOP | MFX_PICSTRUCT_FIELD_PAIRED_PREV) &&
             out->vpp.In.PicStruct != MFX_PICSTRUCT_FIELD_BOTTOM &&
+            out->vpp.In.PicStruct != (MFX_PICSTRUCT_FIELD_BOTTOM | MFX_PICSTRUCT_FIELD_PAIRED_NEXT) &&
+            out->vpp.In.PicStruct != (MFX_PICSTRUCT_FIELD_BOTTOM | MFX_PICSTRUCT_FIELD_PAIRED_PREV) &&
             out->vpp.In.PicStruct != MFX_PICSTRUCT_UNKNOWN)
         {
 


### PR DESCRIPTION
Add the missing PicStruct entries as per https://github.com/intel/vpl-gpu-rt/blob/996a71895d3edf202d0395765eeda49ae3a41a31/_studio/mfx_lib/vpp/src/mfx_vpp_utils.cpp#L208

---

```
[Parsed_scale_qsv_1 @ 0000025f3c335400] Error querying VPP params: unsupported (-3)
[vf#0:0 @ 0000025f310747c0] Error while filtering: Function not implemented
[vf#0:0 @ 0000025f310747c0] Task finished with error code: -40 (Function not implemented)
[vf#0:0 @ 0000025f310747c0] Terminating thread with return code -40 (Function not implemented)
```

Can be reproduced since FFmpeg 6.1 (https://github.com/FFmpeg/FFmpeg/commit/88b3841149b9f41d6c5ec7930dcd5c6caf28b198) using vaapi/d3d11va/software decoder + vpp filter.
```
ffmpeg -hwaccel d3d11va -hwaccel_output_format d3d11 -i clip.mkv -an -sn -vf hwmap=derive_device=qsv,scale_qsv=format=nv12 -f null -

ffmpeg -hwaccel vaapi -hwaccel_output_format vaapi -i clip.mkv -an -sn -vf hwmap=derive_device=qsv,scale_qsv=format=nv12 -f null -

ffmpeg -init_hw_device qsv -i clip.mkv -an -sn -vf vpp_qsv=format=nv12 -f null -
```

Sample clip [clip.zip](https://github.com/user-attachments/files/19427858/clip.zip)